### PR TITLE
Add space in app name

### DIFF
--- a/Sqwarq/DetectXSwift.pkg.recipe
+++ b/Sqwarq/DetectXSwift.pkg.recipe
@@ -25,7 +25,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>app_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/DetectXSwift.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/DetectX Swift.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>


### PR DESCRIPTION
DetectX Swift has a space in the name, which is also present in the download recipe.  However it is not in the pkg recipe