### PR TITLE
GitHubReleasesInfoProvider instead of URLTextSearcher

### DIFF
--- a/Kap/Kap.download.recipe
+++ b/Kap/Kap.download.recipe
@@ -2,16 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Comment</key>
-	<string>Created with Recipe Robot v1.0.5 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
 	<string>Downloads the latest version of Kap.</string>
 	<key>Identifier</key>
 	<string>com.github.autopkg.wardsparadox.download.Kap</string>
 	<key>Input</key>
 	<dict>
-		<key>DOWNLOAD_URL</key>
-		<string>https://kap-updates.now.sh/download/osx</string>
 		<key>NAME</key>
 		<string>Kap</string>
 	</dict>
@@ -20,16 +16,20 @@
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>%NAME%.dmg</string>
-				<key>url</key>
-				<string>%DOWNLOAD_URL%</string>
-			</dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
-		</dict>
+            <key>Arguments</key>
+            <dict>
+                <key>github_repo</key>
+                <string>wulkano/kap</string>
+	            <key>asset_regex</key>
+                <string>(Kap-[0-9]+.[0-9]+.[0-9]+.dmg)</string>
+            </dict>
+                <key>Processor</key>
+                <string>GitHubReleasesInfoProvider</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+        </dict>
 		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
@@ -44,17 +44,6 @@
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_plist_path</key>
-				<string>%pathname%/Kap.app/Contents/Info.plist</string>
-				<key>plist_version_key</key>
-				<string>CFBundleShortVersionString</string>
-			</dict>
-			<key>Processor</key>
-			<string>Versioner</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Modified the recipe to work with GitHubReleasesInfoProvider instead of URLTextSearcher. %version% is given from the GitHubReleasesInfoProvider