### PR TITLE
Add uninstall_method for AirServer

### DIFF
--- a/AirServer/AirServer.munki.recipe
+++ b/AirServer/AirServer.munki.recipe
@@ -30,6 +30,8 @@
                 <string>%NAME%</string>
                 <key>unattended_install</key>
                 <true/>
+                <key>uninstall_method</key>
+                <string>/Applications/AirServer.app/Contents/Resources/uninstall</string>
             </dict>
         </dict>
         <key>MinimumVersion</key>


### PR DESCRIPTION
Points to local uninstall script that's built into the AirServer app bundle