### PR TITLE
Adjust MinimumVersion of recipe

### DIFF
--- a/AdwareMedic/AdwareMedic.munki.recipe
+++ b/AdwareMedic/AdwareMedic.munki.recipe
@@ -40,12 +40,12 @@
       </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.3</string>
+    <string>1.1.0</string>
     <key>Process</key>
     <array>
       <dict>
         <key>Processor</key>
-        <string>com.github.gregneagle.autopkg.sharedprocessors/DeprecationWarning</string>
+        <string>DeprecationWarning</string>
         <key>Arguments</key>
         <dict>
           <key>warning_message</key>


### PR DESCRIPTION
DeprecationWarning requires 1.1.0.