### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/FontNuke/FontNuke.munki.recipe
+++ b/FontNuke/FontNuke.munki.recipe
@@ -82,7 +82,7 @@
            <key>Arguments</key>
            <dict>
                <key>input_plist_path</key>
-               <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+               <string>%RECIPE_CACHE_DIR%/%NAME%/FontNuke.app/Contents/Info.plist</string>
            </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.