### PR TITLE
Basic python3 compatibility

### DIFF
--- a/Google Drive FileStream/DriveFSURLProvider.py
+++ b/Google Drive FileStream/DriveFSURLProvider.py
@@ -6,12 +6,17 @@ by Owen Pragel
 """
 
 from __future__ import absolute_import
-import xml.etree.ElementTree as ET
-import uuid
+
 import urllib2
-import urllib
+import uuid
+import xml.etree.ElementTree as ET
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib import request as urllib  # For Python 3
+except ImportError:
+    import urllib  # For Python 2
 
 __all__ = "DriveFSURLProvider"
 

--- a/Google Drive FileStream/DriveFSURLProvider.py
+++ b/Google Drive FileStream/DriveFSURLProvider.py
@@ -14,9 +14,9 @@ import xml.etree.ElementTree as ET
 from autopkglib import Processor, ProcessorError
 
 try:
-    from urllib import request as urllib  # For Python 3
+    from urllib.parse import urlencode  # For Python 3
 except ImportError:
-    import urllib  # For Python 2
+    from urllib import urlencode  # For Python 2
 
 __all__ = "DriveFSURLProvider"
 
@@ -48,7 +48,7 @@ class DriveFSURLProvider(Processor):
         </request>
         """ % (str(uuid.uuid1()), platform, os_version)
 
-        url_params = urllib.urlencode(params)
+        url_params = urlencode(params)
         url = urllib2.Request('https://tools.google.com/service/update2', data=url_params)
         url.add_header('Content-Type', 'application/xml')
         output_url = urllib2.urlopen(url, xml)

--- a/Google Drive FileStream/DriveFSURLProvider.py
+++ b/Google Drive FileStream/DriveFSURLProvider.py
@@ -5,6 +5,7 @@ From https://gist.github.com/opragel/681fbf91f2d2aba548bac83049bd891b#file-googl
 by Owen Pragel
 """
 
+from __future__ import absolute_import
 import xml.etree.ElementTree as ET
 import uuid
 import urllib2

--- a/Vernier/VernierURLProvider.py
+++ b/Vernier/VernierURLProvider.py
@@ -5,6 +5,7 @@ Vernier Software YML to URL Provider
 """
 
 from __future__ import absolute_import
+
 import urllib2
 import urlparse
 

--- a/Vernier/VernierURLProvider.py
+++ b/Vernier/VernierURLProvider.py
@@ -4,6 +4,7 @@
 Vernier Software YML to URL Provider
 """
 
+from __future__ import absolute_import
 import urllib2
 import urlparse
 


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later (including `urllib2` and `urlparse` in VernierURLProvider), but this should catch the low-hanging fruit right now.