### PR TITLE
Update DriveFS.munki.recipe

### DIFF
--- a/Google Drive FileStream/DriveFS.munki.recipe
+++ b/Google Drive FileStream/DriveFS.munki.recipe
@@ -37,6 +37,7 @@
             <key>blocking_applications</key>
             <array>
               <string>Google Drive File Stream</string>
+              <string>Google Drive</string>
             </array>
             <key>installer_choices_xml</key>
           	<array>


### PR DESCRIPTION
Added Google Drive to blocking applications as Google have renamed the app bundle.