### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/BeardedSpice/BeardedSpice.pkg.recipe
+++ b/BeardedSpice/BeardedSpice.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.autopkg.wardsparadox.pkg.BeardedSpice</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.beardedspice.BeardedSpice</string>
 		<key>NAME</key>
 		<string>BeardedSpice</string>
 	</dict>

--- a/Clipy/Clipy.install.recipe
+++ b/Clipy/Clipy.install.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.wardsparadox.install.Clipy</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.clipy-app.Clipy</string>
 		<key>NAME</key>
 		<string>Clipy</string>
 	</dict>

--- a/MacinMind Software, Inc./Master Key.pkg.recipe
+++ b/MacinMind Software, Inc./Master Key.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.autopkg.wardsparadox.pkg.MasterKey</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.macinmind.masterkey</string>
 		<key>NAME</key>
 		<string>Master Key</string>
 	</dict>

--- a/Mayur Pawashe/Komet.pkg.recipe
+++ b/Mayur Pawashe/Komet.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.autopkg.wardsparadox.pkg.Komet</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>org.zgcoder.Komet</string>
 		<key>NAME</key>
 		<string>Komet</string>
 	</dict>

--- a/Raphael Hanneken/Apple Juice.pkg.recipe
+++ b/Raphael Hanneken/Apple Juice.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.autopkg.wardsparadox.pkg.AppleJuice</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>io.raphaelhanneken.applejuice</string>
 		<key>NAME</key>
 		<string>Apple Juice</string>
 	</dict>

--- a/Sqwarq/DetectXSwift.pkg.recipe
+++ b/Sqwarq/DetectXSwift.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.autopkg.wardsparadox.pkg.DetectXSwift</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.sqwarq.DetectX-Swift</string>
 		<key>NAME</key>
 		<string>DetectXSwift</string>
 	</dict>

--- a/Twocanoes Software, Inc./MacDeployStick.pkg.recipe
+++ b/Twocanoes Software, Inc./MacDeployStick.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.autopkg.wardsparadox.pkg.MacDeployStick</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.twocanoes.MacDeployStick</string>
 		<key>NAME</key>
 		<string>MacDeployStick</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ BeardedSpice/BeardedSpice.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/wardsparadox-recipes/BeardedSpice/BeardedSpice.pkg.recipe
Processing repos/wardsparadox-recipes/BeardedSpice/BeardedSpice.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://raw.github.com/beardedspice/beardedspice/distr/publish/beardedspice-appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 29
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2.2.3
SparkleUpdateInfoProvider: Found URL https://raw.github.com/beardedspice/beardedspice/distr/publish/releases/BeardedSpice-2.2.3.zip
{'Output': {'url': 'https://raw.github.com/beardedspice/beardedspice/distr/publish/releases/BeardedSpice-2.2.3.zip',
            'version': '2.2.3'}}
URLDownloader
{'Input': {'filename': 'BeardedSpice-2.2.3.zip',
           'url': 'https://raw.github.com/beardedspice/beardedspice/distr/publish/releases/BeardedSpice-2.2.3.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.BeardedSpice/downloads/BeardedSpice-2.2.3.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.BeardedSpice/downloads/BeardedSpice-2.2.3.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.BeardedSpice/downloads/BeardedSpice-2.2.3.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.BeardedSpice/BeardedSpice',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename BeardedSpice-2.2.3.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.BeardedSpice/downloads/BeardedSpice-2.2.3.zip to ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.BeardedSpice/BeardedSpice
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.BeardedSpice/BeardedSpice/BeardedSpice.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.beardedspice.BeardedSpice" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "5F2QV47DGC")'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.BeardedSpice/BeardedSpice/BeardedSpice.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.BeardedSpice/BeardedSpice/BeardedSpice.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.BeardedSpice/BeardedSpice/BeardedSpice.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.BeardedSpice/BeardedSpice/BeardedSpice.app',
           'version': '2.2.3'}}
AppPkgCreator: BundleID: com.beardedspice.BeardedSpice
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.BeardedSpice/BeardedSpice/BeardedSpice.app to ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.BeardedSpice/payload/Applications/BeardedSpice.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.beardedspice.BeardedSpice',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.BeardedSpice/BeardedSpice-2.2.3.pkg',
                                                        'version': '2.2.3'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.2.3'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.BeardedSpice/receipts/BeardedSpice.pkg-receipt-20210213-225053.plist

The following packages were built:
    Identifier                     Version  Pkg Path                                                                                                      
    ----------                     -------  --------                                                                                                      
    com.beardedspice.BeardedSpice  2.2.3    ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.BeardedSpice/BeardedSpice-2.2.3.pkg  
```

## ✅ MacinMind Software, Inc./Master Key.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/wardsparadox-recipes/MacinMind\ Software,\ Inc./Master\ Key.pkg.recipe
Processing repos/wardsparadox-recipes/MacinMind Software, Inc./Master Key.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://macinmind.com/pads/MasterKeyappcast2.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 6.2.0.3.63
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 6.2
SparkleUpdateInfoProvider: Found URL https://macinmind.com/MasterKey6.zip
{'Output': {'url': 'https://macinmind.com/MasterKey6.zip', 'version': '6.2'}}
URLDownloader
{'Input': {'filename': 'Master Key-6.2.zip',
           'url': 'https://macinmind.com/MasterKey6.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.MasterKey/downloads/Master Key-6.2.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.MasterKey/downloads/Master '
                        'Key-6.2.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.MasterKey/downloads/Master '
                           'Key-6.2.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.MasterKey/Master '
                               'Key',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Master Key-6.2.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.MasterKey/downloads/Master Key-6.2.zip to ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.MasterKey/Master Key
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.MasterKey/Master '
                         'Key/Master Key.app',
           'requirement': 'identifier "com.macinmind.masterkey" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"2D3239GKS4"'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.MasterKey/Master Key/Master Key.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.MasterKey/Master Key/Master Key.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.MasterKey/Master Key/Master Key.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.MasterKey/Master '
                       'Key/Master Key.app',
           'version': '6.2'}}
AppPkgCreator: BundleID: com.macinmind.masterkey
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.MasterKey/Master Key/Master Key.app to ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.MasterKey/payload/Applications/Master Key.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.macinmind.masterkey',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.MasterKey/Master '
                                                                    'Key-6.2.pkg',
                                                        'version': '6.2'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '6.2'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.MasterKey/receipts/Master Key.pkg-receipt-20210213-225106.plist

The following packages were built:
    Identifier               Version  Pkg Path                                                                                               
    ----------               -------  --------                                                                                               
    com.macinmind.masterkey  6.2      ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.MasterKey/Master Key-6.2.pkg  
```

## ✅ Mayur Pawashe/Komet.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/wardsparadox-recipes/Mayur\ Pawashe/Komet.pkg.recipe
Processing repos/wardsparadox-recipes/Mayur Pawashe/Komet.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://zgcoder.net/software/komet/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 32
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.0
SparkleUpdateInfoProvider: Found URL https://zgcoder.net/software/komet/Komet_1.0.zip
{'Output': {'url': 'https://zgcoder.net/software/komet/Komet_1.0.zip',
            'version': '1.0'}}
URLDownloader
{'Input': {'filename': 'Komet-1.0.zip',
           'url': 'https://zgcoder.net/software/komet/Komet_1.0.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.Komet/downloads/Komet-1.0.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.Komet/downloads/Komet-1.0.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.Komet/downloads/Komet-1.0.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.Komet/Komet',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Komet-1.0.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.Komet/downloads/Komet-1.0.zip to ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.Komet/Komet
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.Komet/Komet/Komet.app',
           'requirement': 'anchor apple generic and identifier '
                          '"org.zgcoder.Komet" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = ZCK58M894E)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.Komet/Komet/Komet.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.Komet/Komet/Komet.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.Komet/Komet/Komet.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.Komet/Komet/Komet.app',
           'version': '1.0'}}
AppPkgCreator: BundleID: org.zgcoder.Komet
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.Komet/Komet/Komet.app to ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.Komet/payload/Applications/Komet.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'org.zgcoder.Komet',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.Komet/Komet-1.0.pkg',
                                                        'version': '1.0'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.Komet/receipts/Komet.pkg-receipt-20210213-225109.plist

The following packages were built:
    Identifier         Version  Pkg Path                                                                                      
    ----------         -------  --------                                                                                      
    org.zgcoder.Komet  1.0      ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.Komet/Komet-1.0.pkg  
```

## ✅ Raphael Hanneken/Apple Juice.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/wardsparadox-recipes/Raphael\ Hanneken/Apple\ Juice.pkg.recipe
Processing repos/wardsparadox-recipes/Raphael Hanneken/Apple Juice.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://raphaelhanneken.github.io/apple-juice/sparkle/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 420
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2020.12.0
SparkleUpdateInfoProvider: Found URL https://github.com/raphaelhanneken/apple-juice/releases/download/2020.12.0/Apple.Juice.dmg
{'Output': {'url': 'https://github.com/raphaelhanneken/apple-juice/releases/download/2020.12.0/Apple.Juice.dmg',
            'version': '2020.12.0'}}
URLDownloader
{'Input': {'filename': 'Apple Juice-2020.12.0.dmg',
           'url': 'https://github.com/raphaelhanneken/apple-juice/releases/download/2020.12.0/Apple.Juice.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.AppleJuice/downloads/Apple Juice-2020.12.0.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.AppleJuice/downloads/Apple '
                        'Juice-2020.12.0.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
AppPkgCreator
{'Input': {'version': '2020.12.0'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.AppleJuice/downloads/Apple Juice-2020.12.0.dmg
AppPkgCreator: Using path '/private/tmp/dmg.CcqgDX/Apple Juice.app' matched from globbed '/private/tmp/dmg.CcqgDX/*.app'.
AppPkgCreator: BundleID: com.raphaelhanneken.applejuice
AppPkgCreator: Copied /private/tmp/dmg.CcqgDX/Apple Juice.app to ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.AppleJuice/payload/Applications/Apple Juice.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.raphaelhanneken.applejuice',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.AppleJuice/Apple '
                                                                    'Juice-2020.12.0.pkg',
                                                        'version': '2020.12.0'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2020.12.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.AppleJuice/receipts/Apple Juice.pkg-receipt-20210213-225120.plist

The following packages were built:
    Identifier                      Version    Pkg Path                                                                                                       
    ----------                      -------    --------                                                                                                       
    com.raphaelhanneken.applejuice  2020.12.0  ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.AppleJuice/Apple Juice-2020.12.0.pkg  
```

## ✅ Sqwarq/DetectXSwift.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/wardsparadox-recipes/Sqwarq/DetectXSwift.pkg.recipe
Processing repos/wardsparadox-recipes/Sqwarq/DetectXSwift.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://s3.amazonaws.com/sqwarq.com/AppCasts/dtxswift.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 1.0971
SparkleUpdateInfoProvider: Found URL https://s3.amazonaws.com/sqwarq.com/PublicZips/DetectX_Swift.app.zip
{'Output': {'url': 'https://s3.amazonaws.com/sqwarq.com/PublicZips/DetectX_Swift.app.zip',
            'version': '1.0971'}}
URLDownloader
{'Input': {'filename': 'DetectXSwift-1.0971.zip',
           'url': 'https://s3.amazonaws.com/sqwarq.com/PublicZips/DetectX_Swift.app.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.DetectXSwift/downloads/DetectXSwift-1.0971.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.DetectXSwift/downloads/DetectXSwift-1.0971.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.DetectXSwift/downloads/DetectXSwift-1.0971.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.DetectXSwift/DetectXSwift/Applications/Utilities',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename DetectXSwift-1.0971.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.DetectXSwift/downloads/DetectXSwift-1.0971.zip to ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.DetectXSwift/DetectXSwift/Applications/Utilities
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.DetectXSwift/DetectXSwift/Applications/Utilities/DetectX '
                         'Swift.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.sqwarq.DetectX-Swift" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = MAJ5XBJSG3)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.DetectXSwift/DetectXSwift/Applications/Utilities/DetectX Swift.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.DetectXSwift/DetectXSwift/Applications/Utilities/DetectX Swift.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.DetectXSwift/DetectXSwift/Applications/Utilities/DetectX Swift.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.DetectXSwift/DetectXSwift/Applications/Utilities/DetectX '
                       'Swift.app',
           'version': '1.0971'}}
AppPkgCreator: BundleID: com.sqwarq.DetectX-Swift
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.DetectXSwift/DetectXSwift/Applications/Utilities/DetectX Swift.app to ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.DetectXSwift/payload/Applications/DetectX Swift.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.sqwarq.DetectX-Swift',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.DetectXSwift/DetectX '
                                                                    'Swift-1.0971.pkg',
                                                        'version': '1.0971'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.0971'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.DetectXSwift/receipts/DetectXSwift.pkg-receipt-20210213-225126.plist

The following packages were built:
    Identifier                Version  Pkg Path                                                                                                        
    ----------                -------  --------                                                                                                        
    com.sqwarq.DetectX-Swift  1.0971   ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.DetectXSwift/DetectX Swift-1.0971.pkg  
```

## ❌ Twocanoes Software, Inc./MacDeployStick.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/wardsparadox-recipes/Twocanoes\ Software,\ Inc./MacDeployStick.pkg.recipe
Processing repos/wardsparadox-recipes/Twocanoes Software, Inc./MacDeployStick.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://www.twocanoes.com/macdeploystick/updates/macdeploystick-software-updates.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 36240
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 3.6
SparkleUpdateInfoProvider: Found URL https://twocanoes-software-updates.s3.amazonaws.com/MDS.dmg
{'Output': {'url': 'https://twocanoes-software-updates.s3.amazonaws.com/MDS.dmg',
            'version': '3.6'}}
URLDownloader
{'Input': {'filename': 'MacDeployStick-3.6.dmg',
           'url': 'https://twocanoes-software-updates.s3.amazonaws.com/MDS.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.MacDeployStick/downloads/MacDeployStick-3.6.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.MacDeployStick/downloads/MacDeployStick-3.6.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.MacDeployStick/downloads/MacDeployStick-3.6.dmg/MDS.pkg',
           'requirement': 'anchor apple generic and identifier '
                          '"com.twocanoes.MacDeployStick" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = UXP6YEHSPW)'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.MacDeployStick/downloads/MacDeployStick-3.6.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "MDS.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2020-11-28 04:52:08 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Twocanoes Software, Inc. (UXP6YEHSPW)
CodeSignatureVerifier:        Expires: 2022-04-19 20:59:59 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            56 2B 45 6B B3 91 03 35 48 1F 94 5B C6 D7 4F 83 F8 EE 38 B3 FA ED 
CodeSignatureVerifier:            53 A4 93 2D 53 60 10 03 D9 77
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '3.6'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.MacDeployStick/downloads/MacDeployStick-3.6.dmg
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.pkg.MacDeployStick/receipts/MacDeployStick.pkg-receipt-20210213-225133.plist

The following recipes failed:
    repos/wardsparadox-recipes/Twocanoes Software, Inc./MacDeployStick.pkg.recipe
        Error in com.github.autopkg.wardsparadox.pkg.MacDeployStick: Processor: AppPkgCreator: Error: Error processing path '/private/tmp/dmg.nWBzBf/*.app' with glob. 

Nothing downloaded, packaged or imported.
```

