### PR TITLE
Fix Installer Choice/Receipt Conflict

### DIFF
--- a/Google Drive FileStream/DriveFS.munki.recipe
+++ b/Google Drive FileStream/DriveFS.munki.recipe
@@ -69,6 +69,17 @@
             <key>Processor</key>
             <string>MunkiImporter</string>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>com.github.keeleysam.recipes.GoogleTalkPlugin/MunkiPkginfoReceiptsEditor</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_ids_set_optional_true</key>
+                <array>
+                    <string>com.google.pkg.Keystone</string>
+                </array>
+            </dict>
+        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
The recipe as is will create a pkginfo file that contains an `install_choices_xml` item to exclude `com.google.pkg.Keystone`. However, the receipts array includes this pkg and so the resulting pkginfo file will continually attempt to install.

This change marks the receipt as optional in the resulting pkginfo file.

Current output:

```xml
		<dict>
			<key>installed_size</key>
			<integer>0</integer>
			<key>packageid</key>
			<string>com.google.pkg.Keystone</string>
			<key>version</key>
			<string>1.3.15.162</string>
		</dict>
```

Updated output:

```xml
		<dict>
			<key>installed_size</key>
			<integer>0</integer>
			<key>optional</key>
			<true/>
			<key>packageid</key>
			<string>com.google.pkg.Keystone</string>
			<key>version</key>
			<string>1.3.15.162</string>
		</dict>
```