### PR TITLE
Add ARCH variable because of M1 Architecture

### DIFF
--- a/Kap/Kap.download.recipe
+++ b/Kap/Kap.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of Kap.</string>
+	<string>Downloads the latest version of Kap - VALID arch FOR THIS RECIPE ARE: x64 (INTEL), arm64 (APPLE SILICON)</string>
 	<key>Identifier</key>
 	<string>com.github.autopkg.wardsparadox.download.Kap</string>
 	<key>Input</key>
@@ -12,7 +12,6 @@
 		<string>Kap</string>
 		<key>ARCH</key>
 		<string></string>
-		<!-- VALID arch FOR THIS RECIPE ARE: x64 (INTEL), arm64 (APPLE SILICON) -->
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>

--- a/Kap/Kap.download.recipe
+++ b/Kap/Kap.download.recipe
@@ -10,6 +10,9 @@
 	<dict>
 		<key>NAME</key>
 		<string>Kap</string>
+		<key>ARCH</key>
+		<string></string>
+		<!-- VALID arch FOR THIS RECIPE ARE: x64 (INTEL), arm64 (APPLE SILICON) -->
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -21,7 +24,7 @@
                 <key>github_repo</key>
                 <string>wulkano/kap</string>
 	            <key>asset_regex</key>
-                <string>(Kap-[0-9]+.[0-9]+.[0-9]+.dmg)</string>
+                <string>(Kap-[0-9]+.[0-9]+.[0-9]+-%ARCH%.dmg)</string>
             </dict>
                 <key>Processor</key>
                 <string>GitHubReleasesInfoProvider</string>


### PR DESCRIPTION
Kap changed their GitHub deployment including M1. To enable this recipe select between architectures, a variable ARCH was added with the requirement to specify between x64 (INTEL) or arm64 (APPLE SILICON).