### PR TITLE
Update Kap recipes with latest GitHub asset patterns

### DIFF
--- a/Kap/Kap.download.recipe
+++ b/Kap/Kap.download.recipe
@@ -3,7 +3,11 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of Kap - VALID arch FOR THIS RECIPE ARE: x64 (INTEL), arm64 (APPLE SILICON)</string>
+	<string>Downloads the latest version of Kap.
+	
+Valid ARCH values are:
+- x86_64 (default, Intel)
+- arm64 (Apple Silicon)</string>
 	<key>Identifier</key>
 	<string>com.github.autopkg.wardsparadox.download.Kap</string>
 	<key>Input</key>
@@ -11,19 +15,32 @@
 		<key>NAME</key>
 		<string>Kap</string>
 		<key>ARCH</key>
-		<string></string>
+		<string>x86_64</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_string</key>
+				<string>%ARCH%</string>
+				<key>find</key>
+				<string>x86_64</string>
+				<key>replace</key>
+				<string>x64</string>
+			</dict>
+		</dict>
+		<dict>
             <key>Arguments</key>
             <dict>
                 <key>github_repo</key>
                 <string>wulkano/kap</string>
 	            <key>asset_regex</key>
-                <string>(Kap-[0-9]+.[0-9]+.[0-9]+-%ARCH%.dmg)</string>
+                <string>(Kap-[\d\.]+-%output_string%.dmg)</string>
             </dict>
                 <key>Processor</key>
                 <string>GitHubReleasesInfoProvider</string>

--- a/Kap/Kap.munki.recipe
+++ b/Kap/Kap.munki.recipe
@@ -28,6 +28,10 @@
 			<string>Kap</string>
 			<key>name</key>
 			<string>%NAME%</string>
+			<key>supported_architectures</key>
+			<array>
+				<string>%ARCH%</string>
+			</array>
 			<key>unattended_install</key>
 			<true/>
 		</dict>


### PR DESCRIPTION
This PR updates the Kap recipes with the latest asset patterns used by the GitHub releases, and adds FindAndReplace to ensure the arch will be usable both for GitHub asset matching and for Munki `supported_architectures` at the same time.

Verbose recipe run with default (Intel) arch specified:

```
% autopkg run -vvq 'Kap/Kap.download.recipe'
Processing Kap/Kap.download.recipe...
WARNING: Kap/Kap.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
com.github.homebysix.FindAndReplace/FindAndReplace
{'Input': {'find': 'x86_64', 'input_string': 'x86_64', 'replace': 'x64'}}
FindAndReplace: Replacing "x86_64" with "x64" in "x86_64".
{'Output': {'output_string': 'x64'}}
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '(Kap-[\\d\\.]+-x64.dmg)',
           'github_repo': 'wulkano/kap'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex '(Kap-[\d\.]+-x64.dmg)' among asset(s): Kap-3.6.0-arm64-mac.zip, Kap-3.6.0-arm64-mac.zip.blockmap, Kap-3.6.0-arm64.dmg, Kap-3.6.0-arm64.dmg.blockmap, Kap-3.6.0-mac.zip, Kap-3.6.0-mac.zip.blockmap, Kap-3.6.0-x64.dmg, Kap-3.6.0-x64.dmg.blockmap, latest-mac.yml
GitHubReleasesInfoProvider: Selected asset 'Kap-3.6.0-x64.dmg' from release ''
{'Output': {'asset_created_at': '2022-10-27T18:12:35Z',
            'asset_url': 'https://api.github.com/repos/wulkano/Kap/releases/assets/82488028',
            'release_notes': '- You can now pause/resume a recording. (thanks '
                             'to @thethomasz)\r\n'
                             '  While recording, Option-click the menu bar '
                             'icon to pause or right-click for more '
                             'options.\r\n'
                             '\r\n'
                             'https://github.com/wulkano/Kap/compare/v3.5.5...v3.6.0',
            'url': 'https://github.com/wulkano/Kap/releases/download/v3.6.0/Kap-3.6.0-x64.dmg',
            'version': '3.6.0'}}
URLDownloader
{'Input': {'url': 'https://github.com/wulkano/Kap/releases/download/v3.6.0/Kap-3.6.0-x64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 27 Oct 2022 18:12:42 GMT
URLDownloader: Storing new ETag header: "0x8DAB846D7163047"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.download.Kap/downloads/Kap-3.6.0-x64.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DAB846D7163047"',
            'last_modified': 'Thu, 27 Oct 2022 18:12:42 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.download.Kap/downloads/Kap-3.6.0-x64.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.download.Kap/downloads/Kap-3.6.0-x64.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.download.Kap/downloads/Kap-3.6.0-x64.dmg/Kap.app',
           'requirement': 'identifier "com.wulkano.kap" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"2KEEHXF6R6"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.download.Kap/downloads/Kap-3.6.0-x64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.cv8rG4/Kap.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.cv8rG4/Kap.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.cv8rG4/Kap.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.download.Kap/receipts/Kap.download-receipt-20241224-202349.plist

The following new items were downloaded:
    Download Path                                                                                                 
    -------------                                                                                                 
    ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.download.Kap/downloads/Kap-3.6.0-x64.dmg  
```

Verbose recipe run with Apple Silicon arch specified:

```
% autopkg run -vvq 'Kap/Kap.download.recipe' -k ARCH=arm64
Processing Kap/Kap.download.recipe...
WARNING: Kap/Kap.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
com.github.homebysix.FindAndReplace/FindAndReplace
{'Input': {'find': 'x86_64', 'input_string': 'arm64', 'replace': 'x64'}}
FindAndReplace: Replacing "x86_64" with "x64" in "arm64".
{'Output': {'output_string': 'arm64'}}
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '(Kap-[\\d\\.]+-arm64.dmg)',
           'github_repo': 'wulkano/kap'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex '(Kap-[\d\.]+-arm64.dmg)' among asset(s): Kap-3.6.0-arm64-mac.zip, Kap-3.6.0-arm64-mac.zip.blockmap, Kap-3.6.0-arm64.dmg, Kap-3.6.0-arm64.dmg.blockmap, Kap-3.6.0-mac.zip, Kap-3.6.0-mac.zip.blockmap, Kap-3.6.0-x64.dmg, Kap-3.6.0-x64.dmg.blockmap, latest-mac.yml
GitHubReleasesInfoProvider: Selected asset 'Kap-3.6.0-arm64.dmg' from release ''
{'Output': {'asset_created_at': '2022-10-27T18:14:47Z',
            'asset_url': 'https://api.github.com/repos/wulkano/Kap/releases/assets/82488449',
            'release_notes': '- You can now pause/resume a recording. (thanks '
                             'to @thethomasz)\r\n'
                             '  While recording, Option-click the menu bar '
                             'icon to pause or right-click for more '
                             'options.\r\n'
                             '\r\n'
                             'https://github.com/wulkano/Kap/compare/v3.5.5...v3.6.0',
            'url': 'https://github.com/wulkano/Kap/releases/download/v3.6.0/Kap-3.6.0-arm64.dmg',
            'version': '3.6.0'}}
URLDownloader
{'Input': {'url': 'https://github.com/wulkano/Kap/releases/download/v3.6.0/Kap-3.6.0-arm64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 27 Oct 2022 18:14:56 GMT
URLDownloader: Storing new ETag header: "0x8DAB84726EDD90A"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.download.Kap/downloads/Kap-3.6.0-arm64.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DAB84726EDD90A"',
            'last_modified': 'Thu, 27 Oct 2022 18:14:56 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.download.Kap/downloads/Kap-3.6.0-arm64.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.download.Kap/downloads/Kap-3.6.0-arm64.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.download.Kap/downloads/Kap-3.6.0-arm64.dmg/Kap.app',
           'requirement': 'identifier "com.wulkano.kap" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"2KEEHXF6R6"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.download.Kap/downloads/Kap-3.6.0-arm64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.Xis7wF/Kap.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.Xis7wF/Kap.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.Xis7wF/Kap.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.download.Kap/receipts/Kap.download-receipt-20241224-202405.plist

The following new items were downloaded:
    Download Path                                                                                                   
    -------------                                                                                                   
    ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.download.Kap/downloads/Kap-3.6.0-arm64.dmg
```