### PR TITLE
Fix naming issue, add installs array

### DIFF
--- a/HiddenBar/Hidden Bar.download.recipe
+++ b/HiddenBar/Hidden Bar.download.recipe
@@ -47,7 +47,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/Hidden Bar/Hidden Bar.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Hidden Bar.app</string>
 				<key>requirement</key>
 				<string>identifier "com.dwarvesv.minimalbar" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = W777S7V8TN)</string>
 			</dict>

--- a/HiddenBar/Hidden Bar.munki.recipe
+++ b/HiddenBar/Hidden Bar.munki.recipe
@@ -5,11 +5,15 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v2.2.0 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of Hidden Bar and imports it into Munki.</string>
+	<string>Downloads the latest version of Hidden Bar and imports it into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator.</string>
 	<key>Identifier</key>
 	<string>com.github.autopkg.wardsparadox.munki.HiddenBar</string>
 	<key>Input</key>
 	<dict>
+		<key>DERIVE_MIN_OS</key>
+		<string>YES</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/%NAME%</string>
 		<key>NAME</key>
@@ -39,15 +43,57 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>Copier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>source_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Hidden Bar.app</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/Applications/Hidden Bar.app</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>derive_minimum_os_version</key>
+				<string>%DERIVE_MIN_OS%</string>
+				<key>faux_root</key>
+				<string>%RECIPE_CACHE_DIR%</string>
+				<key>installs_item_paths</key>
+				<array>
+					<string>/Applications/Hidden Bar.app</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiInstallsItemsCreator</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
-				<string>%pathname%</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+					<string>%RECIPE_CACHE_DIR%/Applications</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
 		</dict>
 	</array>
 </dict>

--- a/HiddenBar/Hidden Bar.pkg.recipe
+++ b/HiddenBar/Hidden Bar.pkg.recipe
@@ -25,7 +25,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>app_path</key>
-				<string>%RECIPE_CACHE_DIR%/Hidden Bar/*.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/*.app</string>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
 			</dict>
 		</dict>
 	</array>


### PR DESCRIPTION
Hi @WardsParadox,

The Hidden Bar recipes failed if the `NAME` variable differs. These changes apply to all three recipes.

Additionally, now an `installs` array gets created, as was done automatically with the dmg source before and the `minimum_os_version` gets set again.

Please be aware that a sync conflict exists. This is due to the change in [Commit 20985d4](https://github.com/autopkg/wardsparadox-recipes/commit/20985d462ca7f045dfe29f9b51b31bb61da75957) – I pulled the master branch before that commit. The change in that commit is outdated by this PR.

Output from a successful autopkg -v run:
```
autopkg run -v HiddenBar/Hidden\ Bar.munki.recipe
Processing HiddenBar/Hidden Bar.munki.recipe...
WARNING: HiddenBar/Hidden Bar.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
GitHubReleasesInfoProvider: Fetching page 1 of GitHub releases
GitHubReleasesInfoProvider: Selected asset 'Hidden-Bar-v1.10-macos.zip' from release 'v1.10'
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/ladmin/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.munki.HiddenBar/downloads/Hidden Bar-1.10.zip
EndOfCheckPhase
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename Hidden Bar-1.10.zip
Unarchiver: Unarchived /Users/ladmin/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.munki.HiddenBar/downloads/Hidden Bar-1.10.zip to /Users/ladmin/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.munki.HiddenBar/Hidden Bar
CodeSignatureVerifier
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/ladmin/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.munki.HiddenBar/Hidden Bar/Hidden Bar.app: valid on disk
CodeSignatureVerifier: /Users/ladmin/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.munki.HiddenBar/Hidden Bar/Hidden Bar.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/ladmin/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.munki.HiddenBar/Hidden Bar/Hidden Bar.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Versioner
Versioner: Found version 1.10 in file /Users/ladmin/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.munki.HiddenBar/downloads/Hidden Bar-1.10.zip/Hidden Bar.app/Contents/Info.plist
AppPkgCreator
AppPkgCreator: Using path '/Users/ladmin/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.munki.HiddenBar/Hidden Bar/Hidden Bar.app' matched from globbed '/Users/ladmin/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.munki.HiddenBar/Hidden Bar/*.app'.
AppPkgCreator: BundleID: com.dwarvesv.minimalbar
AppPkgCreator: Package already exists at path /Users/ladmin/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.munki.HiddenBar/Hidden Bar-1.10.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
Copier
Copier: Copied /Users/ladmin/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.munki.HiddenBar/Hidden Bar/Hidden Bar.app to /Users/ladmin/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.munki.HiddenBar/Applications/Hidden Bar.app
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Hidden Bar.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.13
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.dwarvesv.minimalbar', 'CFBundleName': 'Hidden Bar', 'CFBundleShortVersionString': '1.10', 'CFBundleVersion': '15', 'minosversion': '10.13', 'path': '/Applications/Hidden Bar.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.13'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/ladmin/Repos/munki_local
MunkiImporter: Copied pkginfo to: /Users/ladmin/Repos/munki_local/pkgsinfo/apps/Hidden Bar/Hidden Bar-1.10__11.plist
MunkiImporter:            pkg to: /Users/ladmin/Repos/munki_local/pkgs/apps/Hidden Bar/Hidden Bar-1.10__11.pkg
PathDeleter
PathDeleter: Deleted /Users/ladmin/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.munki.HiddenBar/Hidden Bar
PathDeleter: Deleted /Users/ladmin/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.munki.HiddenBar/Applications
Receipt written to /Users/ladmin/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.munki.HiddenBar/receipts/Hidden Bar.munki-receipt-20260313-093657.plist

The following new items were imported into Munki:
    Name        Version  Catalogs  Pkginfo Path                               Pkg Repo Path                            Icon Repo Path
    ----        -------  --------  ------------                               -------------                            --------------
    Hidden Bar  1.10     testing   apps/Hidden Bar/Hidden Bar-1.10__11.plist  apps/Hidden Bar/Hidden Bar-1.10__11.pkg
```
Output of pre-commit:
```
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check for added large files..............................................Passed
Check Plists.............................................................Passed
Check AutoPkg Recipes....................................................Passed
Forbid AutoPkg Overrides.................................................Passed
Forbid AutoPkg Trust Info................................................Passed
```