### PR TITLE
Verify MacDeployStick package authority chain

### DIFF
--- a/Twocanoes Software, Inc./MacDeployStick.download.recipe
+++ b/Twocanoes Software, Inc./MacDeployStick.download.recipe
@@ -46,8 +46,12 @@
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%/MDS.pkg</string>
-				<key>requirement</key>
-				<string>anchor apple generic and identifier "com.twocanoes.MacDeployStick" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UXP6YEHSPW)</string>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: Twocanoes Software, Inc. (UXP6YEHSPW)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
The recipe passed a designated `requirement` string to `CodeSignatureVerifier`. That argument is not consulted when verifying an installer package, so the signing identity was never checked. This switches to an `expected_authority_names` array (`Developer ID Installer: Twocanoes Software, Inc. (UXP6YEHSPW)` → `Developer ID Certification Authority` → `Apple Root CA`), validating the package's authority chain.

## Verification

`autopkg run -vv` — the change to the `CodeSignatureVerifier` output (before → after):

`% autopkg run -vv com.github.autopkg.wardsparadox.download.MacDeployStick`

```diff
--- before
+++ after
@@ -1,12 +1,9 @@
 CodeSignatureVerifier
-{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.download.MacDeployStick/downloads/MacDeployStick-6.1.dmg/MDS.pkg',
-           'requirement': 'anchor apple generic and identifier '
-                          '"com.twocanoes.MacDeployStick" and (certificate '
-                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
-                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
-                          'exists */ and certificate '
-                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
-                          'and certificate leaf[subject.OU] = UXP6YEHSPW)'}}
+{'Input': {'expected_authority_names': ['Developer ID Installer: Twocanoes '
+                                        'Software, Inc. (UXP6YEHSPW)',
+                                        'Developer ID Certification Authority',
+                                        'Apple Root CA'],
+           'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.download.MacDeployStick/downloads/MacDeployStick-6.1.dmg/MDS.pkg'}}
 CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
 CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.wardsparadox.download.MacDeployStick/downloads/MacDeployStick-6.1.dmg
 CodeSignatureVerifier: Verifying installer package signature...
@@ -34,4 +31,5 @@
 CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
 CodeSignatureVerifier: 
 CodeSignatureVerifier: Signature is valid
+CodeSignatureVerifier: Authority name chain is valid
 {'Output': {}}
```
